### PR TITLE
chore: update biome with recommended astro overrides

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -51,5 +51,22 @@
     "formatter": {
       "quoteStyle": "single"
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["**/*.svelte", "**/*.astro", "**/*.vue"],
+      "linter": {
+        "rules": {
+          "style": {
+            "useConst": "off",
+            "useImportType": "off"
+          },
+          "correctness": {
+            "noUnusedVariables": "off",
+            "noUnusedImports": "off"
+          }
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
### TL;DR

Added Biome linter rule overrides for Svelte, Astro, and Vue files.

### What changed?

Added an `overrides` section to the `biome.json` configuration file that disables specific linting rules for `.svelte`, `.astro`, and `.vue` files:
- Disabled style rules: `useConst` and `useImportType`
- Disabled correctness rules: `noUnusedVariables` and `noUnusedImports`

### How to test?

1. Create or edit a Svelte, Astro, or Vue file with unused variables or imports
2. Run Biome linting on the file
3. Verify that no warnings are shown for the disabled rules

### Why make this change?

These framework files often have template syntax that can trigger false positives with standard JavaScript/TypeScript linting rules. Disabling these specific rules for these file types prevents unnecessary warnings while maintaining linting for other aspects of the code.