### PR TITLE
feat: add className to layout

### DIFF
--- a/src/layouts/layout-prose.astro
+++ b/src/layouts/layout-prose.astro
@@ -1,8 +1,10 @@
 ---
 import CommonHead from '@/components/meta/common-head.astro';
+import { cn } from '@/lib/utils';
 
 interface Props {
   title?: string;
+  className?: string;
 }
 
 // url should probably do this part but i kinda like the simple path
@@ -12,14 +14,14 @@ const homeRoute = nestedRoutes.includes(pathname.split('/')[1])
   ? '/about'
   : '/';
 
-const { title }: Props = Astro.props;
+const { title, className }: Props = Astro.props;
 ---
 
 <html lang="en" class="dark">
   <CommonHead title={title} />
   <body>
-    <main class="h-screen w-screen overflow-x-hidden text-base">
-      <div class="container max-w-screen-sm py-16 md:py-24">
+    <main class="h-screen w-screen overflow-x-hidden text-base flex flex-col">
+      <div class="container max-w-screen-sm py-16 md:py-24 flex-1 flex flex-col">
         <div class="pb-8">
           <a href={homeRoute} class="cursor-custom">
             John
@@ -27,7 +29,9 @@ const { title }: Props = Astro.props;
             Watters
           </a>
         </div>
-        <div class="space-y-12"><slot /></div>
+        <div class={cn("space-y-12 flex-1 flex flex-col", className)}>
+          <slot />
+        </div>
       </div>
     </main>
   </body>


### PR DESCRIPTION
### TL;DR

Enhanced the layout-prose component with flexible styling options and improved container structure.

### What changed?

- Added a `className` prop to the `layout-prose.astro` component to allow custom styling
- Imported the `cn` utility function for class name composition
- Added flex layout properties to the main container and its children:
  - Added `flex flex-col` to the main element
  - Added `flex-1 flex flex-col` to the container div
  - Wrapped the slot in a div with `flex-1 flex flex-col` classes
- Applied the optional `className` prop to the slot container using the `cn` utility

### How to test?

1. Use the layout-prose component with the new `className` prop to verify custom styling works
2. Check that content properly expands to fill available space with the new flex layout
3. Verify that existing pages using this layout still render correctly

### Why make this change?

This change improves the flexibility of the layout-prose component by allowing custom styling through the new `className` prop. The addition of flex layout properties ensures content can properly expand to fill available space, creating a more consistent and adaptable layout structure.