### PR TITLE
chore: update files to check in lefthook hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,7 +2,7 @@ pre-commit:
   parallel: true
   commands:
     check:
-      glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc, md}"
+      glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,md,astro}"
       run: bunx biome check --write --unsafe --no-errors-on-unmatched --files-ignore-unknown=true {staged_files} && git update-index --again
     types:
       run: bun run typecheck
@@ -11,7 +11,7 @@ pre-push:
   parallel: true
   commands:
     check:
-      glob: "*.{js,ts,jsx,tsx,json,md}"
+      glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,md,astro}"
       run: bunx biome check --write --unsafe --no-errors-on-unmatched --files-ignore-unknown=true {staged_files} && git update-index --again
     types:
       run: bun run typecheck


### PR DESCRIPTION
### TL;DR

Added `.astro` files to the Biome formatter glob patterns in lefthook configuration.

### What changed?

- Added `.astro` file extension to the glob patterns in both pre-commit and pre-push hooks
- Fixed a spacing issue in the pre-commit glob pattern (removed space between `jsonc,` and `md`)
- Ensured the pre-push glob pattern matches the pre-commit pattern by adding `cjs`, `mjs`, `d.cts`, `d.mts`, and `jsonc` extensions

### How to test?

1. Create or modify an `.astro` file
2. Stage the changes with `git add`
3. Run `git commit` to trigger the pre-commit hook
4. Verify that Biome formats the `.astro` file correctly

### Why make this change?

To ensure consistent formatting across all project files, including Astro components. This change allows Biome to automatically format `.astro` files during git hooks, maintaining code style consistency throughout the codebase.