### PR TITLE
patch: remove rocket loader disable

### DIFF
--- a/src/layouts/layout-full-screen.astro
+++ b/src/layouts/layout-full-screen.astro
@@ -3,15 +3,13 @@ import CommonHead from '@/components/meta/common-head.astro';
 
 interface Props {
   title?: string;
-  disableRocketLoader?: boolean;
 }
 
-const { title, disableRocketLoader }: Props = Astro.props;
+const { title }: Props = Astro.props;
 ---
 
 <html lang="en" class="dark">
   <CommonHead title={title} />
-  {disableRocketLoader && <script data-cfasync="false" is:inline></script>}
   <body>
     <main class="h-screen w-screen overflow-x-hidden text-base">
       <slot />

--- a/src/pages/running.astro
+++ b/src/pages/running.astro
@@ -57,7 +57,7 @@ const activitiesWithIndex = activities.map((activity) => {
   };
 });
 ---
-<Layout title='Running' disableRocketLoader={true}>
+<Layout title='Running'>
   <div class="absolute mt-16 md:mt-24 z-50 left-1/2 -translate-x-1/2">
     <div class="container flex flex-col space-y-4 w-[min(640px,100vw)]">
       <a href="/" class="cursor-custom">


### PR DESCRIPTION
### TL;DR

Removed the `disableRocketLoader` prop from the full-screen layout component.

### What changed?

- Removed the `disableRocketLoader` prop from the `Props` interface in `layout-full-screen.astro`
- Removed the conditional rendering of the rocket loader script in the layout component
- Updated the `running.astro` page to no longer pass the `disableRocketLoader` prop

### How to test?

1. Navigate to the running page
2. Verify that the page loads correctly without any visual regressions
3. Check that the removal of the rocket loader script doesn't negatively impact page performance

### Why make this change?

The rocket loader script was likely unnecessary for the running page. Removing it simplifies the layout component and reduces potential script overhead. This change streamlines the codebase by eliminating an unused or redundant feature.