### PR TITLE
feat: update reading list

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -13,11 +13,6 @@ interface Reading {
 export const READING: Reading = {
   currently: [
     {
-      name: 'Speaker for the Dead',
-      link: 'https://www.goodreads.com/book/show/7967.Speaker_for_the_Dead',
-      genre: 'Sci-Fi',
-    },
-    {
       name: 'The Almanack of Naval Ravikant',
       link: 'https://www.goodreads.com/book/show/54898389-the-almanack-of-naval-ravikant?ref=nav_sb_ss_1_10',
       genre: 'Personal Development',
@@ -29,6 +24,11 @@ export const READING: Reading = {
     },
   ],
   recommend: [
+    {
+      name: 'Speaker for the Dead',
+      link: 'https://www.goodreads.com/book/show/7967.Speaker_for_the_Dead',
+      genre: 'Sci-Fi',
+    },
     {
       name: "Ender's Game",
       link: 'https://www.goodreads.com/book/show/375802.Ender_s_Game?from_search=true&from_srp=true&qid=ZaEbuHgFCk&rank=1',


### PR DESCRIPTION
### TL;DR

Moved "Speaker for the Dead" from currently reading to recommended books list.

### What changed?

- Removed "Speaker for the Dead" from the `currently` array in the `READING` constant
- Added "Speaker for the Dead" to the `recommend` array in the `READING` constant

### How to test?

1. Run the application and navigate to the reading section
2. Verify that "Speaker for the Dead" no longer appears in the "Currently Reading" section
3. Confirm that "Speaker for the Dead" now appears in the "Recommended Books" section

### Why make this change?

I finished reading "Speaker for the Dead" and want to recommend it to others, so it needed to be moved from my currently reading list to my recommended books list.