### PR TITLE
Simplify portfolio homepage

### DIFF
--- a/src/components/socials/socials.astro
+++ b/src/components/socials/socials.astro
@@ -3,7 +3,7 @@ import SocialBadge from './social-badge.astro';
 ---
 
 <div class="space-y-2">
-  <div>Connect</div>
+  <div class="font-serif italic [font-synthesis:style]">Connect</div>
   <ul class="flex gap-2 flex-wrap">
     <li>
       <SocialBadge href="https://www.linkedin.com/in/john-watters/"

--- a/src/layouts/layout-prose.astro
+++ b/src/layouts/layout-prose.astro
@@ -23,9 +23,9 @@ const { title, className }: Props = Astro.props;
     <main class="h-screen w-screen overflow-x-hidden text-base flex flex-col">
       <div class="container max-w-screen-sm py-16 md:py-24 flex-1 flex flex-col">
         <div class="pb-8">
-          <a href={homeRoute} class="cursor-custom">
+          <a href={homeRoute} class="cursor-custom font-serif">
             John
-            <em class="font-serif text-lg"> (Jack) </em>
+            <em class="italic [font-synthesis:style]"> (Jack) </em>
             Watters
           </a>
         </div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -35,7 +35,7 @@ import { LEARNING, LISTENING, READING, WATCHING } from '@/lib/constants';
         READING.currently.items.slice(0, 3).map((book) => (
           <li>
             <a
-              class="underline underline-offset-4 decoration-muted-foreground hover:underline-offset-[5px] hover:decoration-2 hover:decoration-foreground transition-all"
+              class="inline-link"
               href={book.link}
             >
               {book.name}
@@ -52,7 +52,7 @@ import { LEARNING, LISTENING, READING, WATCHING } from '@/lib/constants';
         LISTENING.currently.items.slice(0, 3).map((item) => (
           <li>
             <a
-              class="underline underline-offset-4 decoration-muted-foreground hover:underline-offset-[5px] hover:decoration-2 hover:decoration-foreground transition-all"
+              class="inline-link"
               href={item.link}
             >
               {item.name}
@@ -69,7 +69,7 @@ import { LEARNING, LISTENING, READING, WATCHING } from '@/lib/constants';
       WATCHING.currently.items.slice(0, 3).map((item) => (
       <li>
         <a
-          class="underline underline-offset-4 decoration-muted-foreground hover:underline-offset-[5px] hover:decoration-2 hover:decoration-foreground transition-all"
+          class="inline-link"
           href={item.link}
           >{item.name}</a
         >

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,74 +1,23 @@
 ---
-import ListLink from '@/components/list/list-link.astro';
-import ListRow from '@/components/list/list-row.astro';
 import Socials from '@/components/socials/socials.astro';
 import Layout from '@/layouts/layout-prose.astro';
-import { BUILDING } from '@/lib/constants';
 ---
 
 <Layout >
   <div class="space-y-6">
     <p>
-      Full stack developer creating elegant, minimalistic software that enhances
-      user experience. Exploring design systems and environmental tech.
+      Californian living in Melbourne, Australia. Working towards a Master of Teaching (Secondary) at <a href="https://www.unimelb.edu.au" class="inline-link">University of Melbourne</a>. Moonlighting as a founding CSR for <a href="https://hospitable.com" class="inline-link">Hospitable</a>'s insurance branch, Align Insurance Services.
     </p>
     <p>
-      Currently serving as the lead developer at a stealth startup and
-      consulting at Insurance BCX. Working on a few personal projects.
+      Experimenting with <a href="https://moodboard.jackwatters.dev" class="inline-link">Mood Boards</a> for inspiration and memory curation.
+
+      Slowly developing a <a href="/secret-tool" class="inline-link">secret tool</a> to expand available tooling for a dear hobby of mine.
+    </p>
+    <p class="italic text-s [font-synthesis:style]">
+      Figuring it out.
     </p>
   </div>
-  <div class="space-y-3 text-sm text-muted-foreground">
-    <a
-      href="/about"
-      class="block underline underline-offset-4 decoration-muted-foreground hover:underline-offset-[5px] hover:decoration-2 hover:decoration-foreground transition-all"
-      >a little more personal</a
-    >
-    <a
-      href="/blog"
-      class="block underline underline-offset-4 decoration-muted-foreground hover:underline-offset-[5px] hover:decoration-2 hover:decoration-foreground transition-all"
-      >unsolicited opinions</a
-    >
-  </div>
-  <div class="space-y-8">
-  {BUILDING.currently.items.length > 0 && (
-    <div class="space-y-3">
-      <a href="/building">Building</a>
-      <ul class="space-y-2 text-sm text-muted-foreground">
-        {
-          BUILDING.currently.items.map((project) => (
-            <ListRow>
-              <ListLink
-                className="underline underline-offset-4 decoration-muted-foreground hover:underline-offset-[5px] hover:decoration-2 hover:decoration-foreground transition-all"
-                href={project.link}
-              >
-                {project.name}
-              </ListLink>
-            </ListRow>
-          ))
-        }
-      </ul>
-    </div>)}
-    {BUILDING.past.items.length > 0 &&
-    (<div class="space-y-3">
-      <a href="/building">Past Projects</a>
-      <ul class="space-y-2 text-sm text-muted-foreground">
-        {
-          BUILDING.past.items.map((project) => (
-            <ListRow>
-              <ListLink
-                className="underline underline-offset-4 decoration-muted-foreground hover:underline-offset-[5px] hover:decoration-2 hover:decoration-foreground transition-all"
-                href={project.link}
-              >
-                {project.name}
-              </ListLink>
-            </ListRow>
-          ))
-        }
-      </ul>
-    </div>)}
-  </div>
   <div class="flex-1 content-end">
-
   <Socials />
   </div>
 </Layout>

--- a/src/pages/running.astro
+++ b/src/pages/running.astro
@@ -60,9 +60,9 @@ const activitiesWithIndex = activities.map((activity) => {
 <Layout title='Running'>
   <div class="absolute mt-16 md:mt-24 z-50 left-1/2 -translate-x-1/2">
     <div class="container flex flex-col space-y-4 w-[min(640px,100vw)]">
-      <a href="/" class="cursor-custom">
+      <a href="/" class="cursor-custom font-serif">
         John
-        <em class="font-serif text-lg"> (Jack) </em>
+        <em class="italic [font-synthesis:style]"> (Jack) </em>
         Watters
       </a>
       <p class="text-sm text-muted-foreground">

--- a/src/pages/secret-tool.astro
+++ b/src/pages/secret-tool.astro
@@ -1,0 +1,25 @@
+---
+import Layout from '@/layouts/layout-full-screen.astro';
+---
+
+<Layout title="Secret Tool">
+	<div class="secret-tool-reveal" aria-label="Secret tool coming soon">?</div>
+</Layout>
+
+<style>
+	.secret-tool-reveal {
+		display: grid;
+		width: 100%;
+		height: 100%;
+		place-items: center;
+		user-select: none;
+		cursor: help;
+		color: hsl(var(--muted-foreground));
+		font-family: Helvetica, Arial, sans-serif;
+		font-size: clamp(10rem, 30vh, 18rem);
+		font-style: italic;
+		font-synthesis: style;
+		font-weight: 400;
+		line-height: 0.8;
+	}
+</style>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,14 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer components {
+	.inline-link {
+		@apply text-muted-foreground italic underline underline-offset-4 decoration-muted-foreground transition-all hover:underline-offset-[5px] hover:decoration-2 hover:decoration-foreground;
+		margin-inline-end: 0.08em;
+		font-synthesis: style;
+	}
+}
+
 @layer base {
 	:root {
 		--background: #fffbeb;
@@ -115,9 +123,8 @@
 
 
 	::selection {
-    background: var(--color-orange);
-    color: white;
-  }
+		background: rgb(255 255 255 / 18%);
+	}
 
 	@font-face {
 		font-family: 'Inconsolata';
@@ -132,7 +139,7 @@
 		font-style: normal;
 		font-weight: 400;
 		font-display: swap;
-		src: url(/fonts/Newsreader.ttf) format('ttf');
+		src: url(/fonts/Newsreader.ttf) format('truetype');
 	}
 }
 


### PR DESCRIPTION
## Summary
- simplify the homepage into a focused single-page introduction
- refine Newsreader and italic typography for headings and inline links
- add a hidden secret-tool teaser page
- improve link spacing and text-selection styling

## Validation
- `bunx astro check`
- `tsc --noEmit`